### PR TITLE
url to git clone didn't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This example demonstrates how the `ol` package can be used with browserify.
 
 Clone the project.
 
-    git clone git@github.com:openlayers/ol-browserify.git
+    git clone https://github.com/openlayers/ol-browserify.git
 
 Install the project dependencies.
 


### PR DESCRIPTION
old url resulted in Permission denied error:
```
gawi@uni-new:~/workspace$ git clone git@github.com:openlayers/ol-browserify.git
Cloning into 'ol-browserify'...
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```